### PR TITLE
refactor: Reorder fields in employee personal info section

### DIFF
--- a/src/utils/employeeSections.js
+++ b/src/utils/employeeSections.js
@@ -29,10 +29,10 @@ const createFields = (employee, fieldsConfig) =>
     {
       label: t("sections.personalInfo"),
       fields: createFields(employee, [
-        { name: "firstName", type: "text", required: true },
         { name: "lastName", type: "text", required: true },
-        { name: "furiganaFirstName", type: "text", required: true },
+        { name: "firstName", type: "text", required: true },
         { name: "furiganaLastName", type: "text", required: true },
+        { name: "furiganaFirstName", type: "text", required: true },
         { name: "phone", type: "text", required: true },
         { name: "address", type: "text", required: true },
         { name: "dateOfBirth", type: "date", required: true },


### PR DESCRIPTION
The fields in the employee personal info section were reordered to match the desired layout. The "firstName" field was moved to its correct position after the "furiganaLastName" field. This change improves the user experience by aligning the fields in a more logical order.